### PR TITLE
Replaced usage of dict() by {} to define dictionaries

### DIFF
--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -59,9 +59,9 @@ def _call_ipptool(printer_uri, request):
 
 
 def cancel_job_request(printer_uri=None, purge_job=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'purge_job': purge_job}})
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'purge_job': purge_job}}}
     request = cancel_job_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
@@ -76,13 +76,13 @@ def create_printer_subscription(printer_uri=None,
     """
     Create a new subscription and return its id
     """
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'requesting_user_name': requesting_user_name}},
-              notify_recipient_uri=notify_recipient_uri,
-              notify_events=notify_events,
-              notify_lease_duration=notify_lease_duration,
-              notify_lease_expiration_time=notify_lease_expiration_time)
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'requesting_user_name': requesting_user_name}},
+          'notify_recipient_uri': notify_recipient_uri,
+          'notify_events': notify_events,
+          'notify_lease_duration': notify_lease_duration,
+          'notify_lease_expiration_time': notify_lease_expiration_time}
     request = create_printer_subscription_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     return response['Tests'][0]['notify-subscription-id']
@@ -97,9 +97,9 @@ def cups_add_modify_class_request(printer_uri=None, device_uri=None):
 
 
 def cups_add_modify_printer_request(printer_uri=None, device_uri=None):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri}},
-              device_uri=device_uri)
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri}},
+          'device_uri': device_uri}
     request = cups_add_modify_printer_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
@@ -140,19 +140,19 @@ def cups_get_ppds_request(printer_uri=None,
                           ppd_psversion=colander.null,
                           ppd_type=colander.null,
                           requested_attributes=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'exclude_schemes': exclude_schemes,
-                       'include_schemes': include_schemes,
-                       'limit': limit,
-                       'ppd_make': ppd_make,
-                       'ppd_make_and_model': ppd_make_and_model,
-                       'ppd_model_number': ppd_model_number,
-                       'ppd_natural_language': ppd_natural_language,
-                       'ppd_product': ppd_product,
-                       'ppd_psversion': ppd_psversion,
-                       'ppd_type': ppd_type,
-                       'requested_attributes': requested_attributes
-                       }})
+    kw = {'header': {'operation_attributes':
+                     {'exclude_schemes': exclude_schemes,
+                      'include_schemes': include_schemes,
+                      'limit': limit,
+                      'ppd_make': ppd_make,
+                      'ppd_make_and_model': ppd_make_and_model,
+                      'ppd_model_number': ppd_model_number,
+                      'ppd_natural_language': ppd_natural_language,
+                      'ppd_product': ppd_product,
+                      'ppd_psversion': ppd_psversion,
+                      'ppd_type': ppd_type,
+                      'requested_attributes': requested_attributes
+                      }}}
     request = cups_get_ppds_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     return response['Tests'][0]['ResponseAttributes']
@@ -185,12 +185,12 @@ def cups_move_job_request(printer_uri=colander.null,
                           job_uri=colander.null,
                           job_printer_uri=None,
                           printer_state_message=None):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'job_id': job_id,
-                       'job_uri': job_uri}},
-              job_printer_uri=job_printer_uri,
-              printer_state_message=printer_state_message)
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'job_id': job_id,
+                      'job_uri': job_uri}},
+          'job_printer_uri': job_printer_uri,
+          'printer_state_message': printer_state_message}
     request = cups_move_job_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
@@ -200,10 +200,10 @@ def cups_move_job_request(printer_uri=colander.null,
 def cups_reject_jobs_request(printer_uri=None,
                              requesting_user_name=None,
                              printer_state_message=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'requesting_user_name': requesting_user_name}},
-              printer_state_message=printer_state_message)
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'requesting_user_name': requesting_user_name}},
+          'printer_state_message': printer_state_message}
     request = cups_reject_jobs_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
@@ -215,12 +215,12 @@ def get_job_attributes_request(printer_uri=None,
                                job_uri=colander.null,
                                requesting_user_name=colander.null,
                                requested_attributes=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'job_id': job_id,
-                       'job_uri': job_uri,
-                       'requesting_user_name': requesting_user_name,
-                       'requested_attributes': requested_attributes}})
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'job_id': job_id,
+                      'job_uri': job_uri,
+                      'requesting_user_name': requesting_user_name,
+                      'requested_attributes': requested_attributes}}}
     request = get_job_attributes_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     return response['Tests'][0]['ResponseAttributes']
@@ -231,12 +231,12 @@ def get_jobs_request(printer_uri=None,
                      requested_attributes=colander.null,
                      which_jobs=colander.null,
                      my_jobs=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'limit': limit,
-                       'requested_attributes': requested_attributes,
-                       'which_jobs': which_jobs,
-                       'my_jobs': my_jobs}})
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'limit': limit,
+                      'requested_attributes': requested_attributes,
+                      'which_jobs': which_jobs,
+                      'my_jobs': my_jobs}}}
     request = get_jobs_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     return response['Tests'][0]['ResponseAttributes']
@@ -247,12 +247,12 @@ def get_subscriptions_request(printer_uri=None,
                               requested_attributes=colander.null,
                               which_jobs=colander.null,
                               my_jobs=colander.null):
-    kw = dict(header={'operation_attributes':
-                      {'printer_uri': printer_uri,
-                       'limit': limit,
-                       'requested_attributes': requested_attributes,
-                       'which_jobs': which_jobs,
-                       'my_jobs': my_jobs}})
+    kw = {'header': {'operation_attributes':
+                     {'printer_uri': printer_uri,
+                      'limit': limit,
+                      'requested_attributes': requested_attributes,
+                      'which_jobs': which_jobs,
+                      'my_jobs': my_jobs}}}
     request = get_subscriptions_form.render(kw)
     response = _call_ipptool(printer_uri, request)
     return response['Tests'][0]['ResponseAttributes']


### PR DESCRIPTION
As pointed out by @ticosax using the literal approach (`{}`) to create dictionaries is more performant than the function version (`dict()`). See http://doughellmann.com/2012/11/the-performance-impact-of-using-dict-instead-of-in-cpython-2-7-2.html for an interesting analysis.
