### PR TITLE
Some improvements 

### DIFF
--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -30,25 +30,25 @@ config.read(['/etc/pyipptool/pyipptool.cfg',
 ipptool_path = config.get('main', 'ipptool_path')
 
 
-def authenticate_printer_uri(printer_uri):
+def authenticate_uri(uri):
     login = config.get('main', 'login')
     password = config.get('main', 'password')
     if login:
-        parsed_url = urlparse.urlparse(printer_uri)
+        parsed_url = urlparse.urlparse(uri)
         authenticated_netloc = '{}:{}@{}'.format(login, password,
                                                  parsed_url.netloc)
-        authenticated_printer_uri = urlparse.ParseResult(parsed_url[0],
-                                                         authenticated_netloc,
-                                                         *parsed_url[2:])
-        return authenticated_printer_uri.geturl()
-    return printer_uri
+        authenticated_uri = urlparse.ParseResult(parsed_url[0],
+                                                 authenticated_netloc,
+                                                 *parsed_url[2:])
+        return authenticated_uri.geturl()
+    return uri
 
 
-def _call_ipptool(printer_uri, request):
+def _call_ipptool(uri, request):
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_file.write(request)
     process = subprocess.Popen([ipptool_path,
-                                authenticate_printer_uri(printer_uri),
+                                authenticate_uri(uri),
                                 '-X',
                                 temp_file.name],
                                stdin=subprocess.PIPE,
@@ -74,16 +74,17 @@ def release_job(uri,
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
 
 
-def cancel_job_request(printer_uri=None, purge_job=colander.null):
+def cancel_job_request(uri, printer_uri=colander.null, purge_job=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'purge_job': purge_job}}}
     request = cancel_job_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
 
 
-def create_printer_subscription(printer_uri=None,
+def create_printer_subscription(uri,
+                                printer_uri=None,
                                 requesting_user_name=None,
                                 notify_recipient_uri=None,
                                 notify_events=None,
@@ -100,45 +101,46 @@ def create_printer_subscription(printer_uri=None,
           'notify_lease_duration': notify_lease_duration,
           'notify_lease_expiration_time': notify_lease_expiration_time}
     request = create_printer_subscription_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['notify-subscription-id']
 
 
-def cups_add_modify_class_request(printer_uri=None, device_uri=None):
+def cups_add_modify_class_request(uri, printer_uri=None, device_uri=None):
     kw = {'printer_uri': printer_uri, 'device_uri': device_uri}
     request = cups_add_modify_class_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def cups_add_modify_printer_request(printer_uri=None, device_uri=None):
+def cups_add_modify_printer_request(uri, printer_uri=None, device_uri=None):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri}},
           'device_uri': device_uri}
     request = cups_add_modify_printer_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def cups_delete_printer(printer_uri=None):
+def cups_delete_printer(uri, printer_uri=None):
     kw = {'header': {'operation_attributes': {'printer_uri': printer_uri}}}
     request = cups_delete_printer_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def cups_delete_class(printer_uri=None):
+def cups_delete_class(uri, printer_uri=None):
     kw = {'header': {'operation_attributes': {'printer_uri': printer_uri}}}
     request = cups_delete_class_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def cups_get_classes_request(printer_uri=None,
+def cups_get_classes_request(uri,
+                             printer_uri=None,
                              first_printer_name=colander.null,
                              limit=colander.null,
                              printer_location=colander.null,
@@ -156,11 +158,12 @@ def cups_get_classes_request(printer_uri=None,
                       'requested_attributes': requested_attributes,
                       'requested_user_name': requested_user_name}}}
     request = cups_get_classes_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_get_ppds_request(printer_uri=None,
+def cups_get_ppds_request(uri,
+                          printer_uri=None,
                           exclude_schemes=colander.null,
                           include_schemes=colander.null,
                           limit=colander.null,
@@ -186,11 +189,12 @@ def cups_get_ppds_request(printer_uri=None,
                       'requested_attributes': requested_attributes
                       }}}
     request = cups_get_ppds_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_get_printers_request(printer_uri=None,
+def cups_get_printers_request(uri,
+                              printer_uri=None,
                               first_printer_name=colander.null,
                               limit=colander.null,
                               printer_location=colander.null,
@@ -208,11 +212,12 @@ def cups_get_printers_request(printer_uri=None,
                       'requested_attributes': requested_attributes,
                       'requested_user_name': requested_user_name}}}
     request = cups_get_printers_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_move_job_request(printer_uri=colander.null,
+def cups_move_job_request(uri,
+                          printer_uri=colander.null,
                           job_id=colander.null,
                           job_uri=colander.null,
                           job_printer_uri=None,
@@ -224,12 +229,13 @@ def cups_move_job_request(printer_uri=colander.null,
           'job_printer_uri': job_printer_uri,
           'printer_state_message': printer_state_message}
     request = cups_move_job_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def cups_reject_jobs_request(printer_uri=None,
+def cups_reject_jobs_request(uri,
+                             printer_uri=None,
                              requesting_user_name=None,
                              printer_state_message=colander.null):
     kw = {'header': {'operation_attributes':
@@ -237,12 +243,13 @@ def cups_reject_jobs_request(printer_uri=None,
                       'requesting_user_name': requesting_user_name}},
           'printer_state_message': printer_state_message}
     request = cups_reject_jobs_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
     return True
 
 
-def get_job_attributes_request(printer_uri=None,
+def get_job_attributes_request(uri,
+                               printer_uri=None,
                                job_id=colander.null,
                                job_uri=colander.null,
                                requesting_user_name=colander.null,
@@ -254,11 +261,12 @@ def get_job_attributes_request(printer_uri=None,
                       'requesting_user_name': requesting_user_name,
                       'requested_attributes': requested_attributes}}}
     request = get_job_attributes_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']
 
 
-def get_jobs_request(printer_uri=None,
+def get_jobs_request(uri,
+                     printer_uri=None,
                      limit=colander.null,
                      requested_attributes=colander.null,
                      which_jobs=colander.null,
@@ -270,11 +278,12 @@ def get_jobs_request(printer_uri=None,
                       'which_jobs': which_jobs,
                       'my_jobs': my_jobs}}}
     request = get_jobs_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']
 
 
-def get_subscriptions_request(printer_uri=None,
+def get_subscriptions_request(uri,
+                              printer_uri=None,
                               limit=colander.null,
                               requested_attributes=colander.null,
                               which_jobs=colander.null,
@@ -286,5 +295,5 @@ def get_subscriptions_request(printer_uri=None,
                       'which_jobs': which_jobs,
                       'my_jobs': my_jobs}}}
     request = get_subscriptions_form.render(kw)
-    response = _call_ipptool(printer_uri, request)
+    response = _call_ipptool(uri, request)
     return response['Tests'][0]['ResponseAttributes']

--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -74,7 +74,7 @@ def release_job(uri,
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
 
 
-def cancel_job_request(uri, printer_uri=colander.null, purge_job=colander.null):
+def cancel_job(uri, printer_uri=colander.null, purge_job=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'purge_job': purge_job}}}
@@ -105,7 +105,7 @@ def create_printer_subscription(uri,
     return response['Tests'][0]['notify-subscription-id']
 
 
-def cups_add_modify_class_request(uri, printer_uri=None, device_uri=None):
+def cups_add_modify_class(uri, printer_uri=None, device_uri=None):
     kw = {'printer_uri': printer_uri, 'device_uri': device_uri}
     request = cups_add_modify_class_form.render(kw)
     response = _call_ipptool(uri, request)
@@ -113,7 +113,7 @@ def cups_add_modify_class_request(uri, printer_uri=None, device_uri=None):
     return True
 
 
-def cups_add_modify_printer_request(uri, printer_uri=None, device_uri=None):
+def cups_add_modify_printer(uri, printer_uri=None, device_uri=None):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri}},
           'device_uri': device_uri}
@@ -139,15 +139,15 @@ def cups_delete_class(uri, printer_uri=None):
     return True
 
 
-def cups_get_classes_request(uri,
-                             printer_uri=None,
-                             first_printer_name=colander.null,
-                             limit=colander.null,
-                             printer_location=colander.null,
-                             printer_type=colander.null,
-                             printer_type_mask=colander.null,
-                             requested_attributes=colander.null,
-                             requested_user_name=colander.null):
+def cups_get_classes(uri,
+                     printer_uri=None,
+                     first_printer_name=colander.null,
+                     limit=colander.null,
+                     printer_location=colander.null,
+                     printer_type=colander.null,
+                     printer_type_mask=colander.null,
+                     requested_attributes=colander.null,
+                     requested_user_name=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'first_printer_name': first_printer_name,
@@ -162,19 +162,19 @@ def cups_get_classes_request(uri,
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_get_ppds_request(uri,
-                          printer_uri=None,
-                          exclude_schemes=colander.null,
-                          include_schemes=colander.null,
-                          limit=colander.null,
-                          ppd_make=colander.null,
-                          ppd_make_and_model=colander.null,
-                          ppd_model_number=colander.null,
-                          ppd_natural_language=colander.null,
-                          ppd_product=colander.null,
-                          ppd_psversion=colander.null,
-                          ppd_type=colander.null,
-                          requested_attributes=colander.null):
+def cups_get_ppds(uri,
+                  printer_uri=None,
+                  exclude_schemes=colander.null,
+                  include_schemes=colander.null,
+                  limit=colander.null,
+                  ppd_make=colander.null,
+                  ppd_make_and_model=colander.null,
+                  ppd_model_number=colander.null,
+                  ppd_natural_language=colander.null,
+                  ppd_product=colander.null,
+                  ppd_psversion=colander.null,
+                  ppd_type=colander.null,
+                  requested_attributes=colander.null):
     kw = {'header': {'operation_attributes':
                      {'exclude_schemes': exclude_schemes,
                       'include_schemes': include_schemes,
@@ -193,15 +193,15 @@ def cups_get_ppds_request(uri,
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_get_printers_request(uri,
-                              printer_uri=None,
-                              first_printer_name=colander.null,
-                              limit=colander.null,
-                              printer_location=colander.null,
-                              printer_type=colander.null,
-                              printer_type_mask=colander.null,
-                              requested_attributes=colander.null,
-                              requested_user_name=colander.null):
+def cups_get_printers(uri,
+                      printer_uri=None,
+                      first_printer_name=colander.null,
+                      limit=colander.null,
+                      printer_location=colander.null,
+                      printer_type=colander.null,
+                      printer_type_mask=colander.null,
+                      requested_attributes=colander.null,
+                      requested_user_name=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'first_printer_name': first_printer_name,
@@ -216,12 +216,12 @@ def cups_get_printers_request(uri,
     return response['Tests'][0]['ResponseAttributes']
 
 
-def cups_move_job_request(uri,
-                          printer_uri=colander.null,
-                          job_id=colander.null,
-                          job_uri=colander.null,
-                          job_printer_uri=None,
-                          printer_state_message=None):
+def cups_move_job(uri,
+                  printer_uri=colander.null,
+                  job_id=colander.null,
+                  job_uri=colander.null,
+                  job_printer_uri=None,
+                  printer_state_message=None):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'job_id': job_id,
@@ -234,10 +234,10 @@ def cups_move_job_request(uri,
     return True
 
 
-def cups_reject_jobs_request(uri,
-                             printer_uri=None,
-                             requesting_user_name=None,
-                             printer_state_message=colander.null):
+def cups_reject_jobs(uri,
+                     printer_uri=None,
+                     requesting_user_name=None,
+                     printer_state_message=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'requesting_user_name': requesting_user_name}},
@@ -248,12 +248,12 @@ def cups_reject_jobs_request(uri,
     return True
 
 
-def get_job_attributes_request(uri,
-                               printer_uri=None,
-                               job_id=colander.null,
-                               job_uri=colander.null,
-                               requesting_user_name=colander.null,
-                               requested_attributes=colander.null):
+def get_job_attributes(uri,
+                       printer_uri=None,
+                       job_id=colander.null,
+                       job_uri=colander.null,
+                       requesting_user_name=colander.null,
+                       requested_attributes=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'job_id': job_id,
@@ -265,12 +265,12 @@ def get_job_attributes_request(uri,
     return response['Tests'][0]['ResponseAttributes']
 
 
-def get_jobs_request(uri,
-                     printer_uri=None,
-                     limit=colander.null,
-                     requested_attributes=colander.null,
-                     which_jobs=colander.null,
-                     my_jobs=colander.null):
+def get_jobs(uri,
+             printer_uri=None,
+             limit=colander.null,
+             requested_attributes=colander.null,
+             which_jobs=colander.null,
+             my_jobs=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'limit': limit,
@@ -282,12 +282,12 @@ def get_jobs_request(uri,
     return response['Tests'][0]['ResponseAttributes']
 
 
-def get_subscriptions_request(uri,
-                              printer_uri=None,
-                              limit=colander.null,
-                              requested_attributes=colander.null,
-                              which_jobs=colander.null,
-                              my_jobs=colander.null):
+def get_subscriptions(uri,
+                      printer_uri=None,
+                      limit=colander.null,
+                      requested_attributes=colander.null,
+                      which_jobs=colander.null,
+                      my_jobs=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
                       'limit': limit,

--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -74,9 +74,15 @@ def release_job(uri,
     assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
 
 
-def cancel_job(uri, printer_uri=colander.null, purge_job=colander.null):
+def cancel_job(uri,
+               printer_uri=colander.null,
+               job_id=colander.null,
+               job_uri=colander.null,
+               purge_job=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
+                      'job_id': job_id,
+                      'job_uri': job_uri,
                       'purge_job': purge_job}}}
     request = cancel_job_form.render(kw)
     response = _call_ipptool(uri, request)

--- a/pyipptool/schemas.py
+++ b/pyipptool/schemas.py
@@ -65,8 +65,7 @@ class JobOperationAttributes(OperationAttributesWithPrinterUri,
                                  widget=IPPAttributeWidget())
 
 
-class CancelJobOperationAttributes(OperationAttributesWithPrinterUri):
-    job_uri = colander.SchemaNode(Uri(), widget=IPPAttributeWidget())
+class CancelJobOperationAttributes(JobOperationAttributes):
     purge_job = colander.SchemaNode(colander.Boolean(true_val=1, false_val=0),
                                     widget=IPPAttributeWidget())
 

--- a/pyipptool/tests/test_form.py
+++ b/pyipptool/tests/test_form.py
@@ -3,10 +3,14 @@ def test_cancel_job_form():
     request = cancel_job_form.render(
         {'header': {'operation_attributes':
                     {'printer_uri': 'https://localhost:631/classes/PIY',
+                     'job_id': 8,
+                     'job_uri': 'https://localhost:631/jobs/8',
                      'purge_job': True}}})
     assert 'NAME "Cancel Job"' in request
     assert 'OPERATION "Cancel-Job"' in request
     assert 'ATTR uri printer-uri https://localhost:631/classes/PIY' in request
+    assert 'ATTR integer job-id 8' in request
+    assert 'ATTR uri job-uri https://localhost:631/jobs/8' in request
     assert 'ATTR boolean purge-job 1' in request
 
 

--- a/pyipptool/tests/test_highlevel.py
+++ b/pyipptool/tests/test_highlevel.py
@@ -7,14 +7,14 @@ import pyipptool
 def test_ipptool_create_printer_subscription(_call_ipptool):
     from pyipptool import create_printer_subscription
     create_printer_subscription(
+        uri='https://localhost:631/',
         printer_uri='https://localhost:631/classes/PUBLIC-PDF',
         requesting_user_name='ecp_admin',
         notify_recipient_uri='ezpnotifier://',
         notify_events='all',
         notify_lease_duration=0,
         notify_lease_expiration_time=0)
-    assert _call_ipptool._mock_mock_calls[0][1][0] == ('https://localhost:631/'
-                                                       'classes/PUBLIC-PDF')
+    assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
     request = _call_ipptool._mock_mock_calls[0][1][1]
     assert 'requesting-user-name ecp_admin' in request, request
     assert 'printer-uri https://localhost:631/classes/PUBLIC-PDF' in request
@@ -29,9 +29,10 @@ def test_cups_add_modify_printer_request(_call_ipptool):
     from pyipptool import cups_add_modify_printer_request
     _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
     cups_add_modify_printer_request(
+        uri='https://localhost:631/',
         printer_uri='https://localhost:631/classes/PUBLIC-PDF',
         device_uri='cups-pdf:/')
-    assert _call_ipptool._mock_mock_calls[0][1][0] == ('https://localhost:631/'
-                                                       'classes/PUBLIC-PDF')
+    assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
     request = _call_ipptool._mock_mock_calls[0][1][1]
+    assert 'printer-uri https://localhost:631/classes/PUBLIC-PDF' in request
     assert 'device-uri cups-pdf:/' in request

--- a/pyipptool/tests/test_highlevel.py
+++ b/pyipptool/tests/test_highlevel.py
@@ -25,10 +25,10 @@ def test_ipptool_create_printer_subscription(_call_ipptool):
 
 
 @mock.patch.object(pyipptool, '_call_ipptool')
-def test_cups_add_modify_printer_request(_call_ipptool):
-    from pyipptool import cups_add_modify_printer_request
+def test_cups_add_modify_printer(_call_ipptool):
+    from pyipptool import cups_add_modify_printer
     _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
-    cups_add_modify_printer_request(
+    cups_add_modify_printer(
         uri='https://localhost:631/',
         printer_uri='https://localhost:631/classes/PUBLIC-PDF',
         device_uri='cups-pdf:/')


### PR DESCRIPTION
##### (1) Added mandatory uri argument, when performing pip requests

> ipptool sends IPP requests to the specified URI ...

for full details, _see_ the [ipptool synopsis](http://www.cups.org/documentation.php/doc-1.7/man-ipptool.html)
##### (2) Removed request word in function name for IPP operation
##### (3) Fixed `Cancel-Job` operation
