### PR TITLE
Fixed group tag name for printer object

### DIFF
--- a/pyipptool/schemas.py
+++ b/pyipptool/schemas.py
@@ -212,7 +212,7 @@ class CupsAddModifyPrinterSchema(BaseIPPSchema):
     header = HeaderIPPSchema(widget=IPPConstantTupleWidget())
     header['operation_attributes'] = OperationAttributesWithPrinterUri(
         widget=IPPTupleWidget())
-    object_attributes_tag = 'printer-object-attributes-tag'
+    object_attributes_tag = 'printer-attributes-tag'
     auth_info_required = colander.SchemaNode(Keyword(),
                                              widget=IPPAttributeWidget())
     job_sheets_default = colander.SchemaNode(Name(),
@@ -303,7 +303,7 @@ class CupsMoveJobSchema(BaseIPPSchema):
 class CupsRejectJobsSchema(BaseIPPSchema):
     name = 'CUPS Reject Jobs'
     operation = 'CUPS-Reject-Jobs'
-    object_attributes_tag = 'printer-object-attributes-tag'
+    object_attributes_tag = 'printer-attributes-tag'
     printer_state_message = colander.SchemaNode(
         Text(),
         widget=IPPAttributeWidget())

--- a/pyipptool/tests/test_form.py
+++ b/pyipptool/tests/test_form.py
@@ -76,7 +76,7 @@ def test_cups_add_modify_class_form():
          'requesting_user_name_allowed': 'me'})
     assert 'NAME "CUPS Add Modify Class"'
     assert 'OPERATION "CUPS-Add-Modify-Class"' in request
-    assert 'GROUP printer-object-attributes-tag' in request
+    assert 'GROUP printer-attributes-tag' in request
     assert 'ATTR uri device-uri cups-pdf:/' in request
     assert 'ATTR keyword auth-info-required john' in request, request
     assert 'ATTR name job-sheets-default none' in request, request
@@ -111,7 +111,7 @@ def test_cups_add_modify_printer_form():
     assert 'NAME "CUPS Add Modify Printer"'
     assert 'OPERATION "CUPS-Add-Modify-Printer"' in request
     assert 'ATTR uri printer-uri https://localhost:631/printers/p0' in request
-    assert 'GROUP printer-object-attributes-tag' in request
+    assert 'GROUP printer-attributes-tag' in request
     assert 'ATTR uri device-uri cups-pdf:/' in request
     assert 'ATTR keyword auth-info-required john' in request
     assert 'ATTR name job-sheets-default none' in request
@@ -158,7 +158,7 @@ def test_cups_get_classes_form():
                      'printer_type': 'network',
                      'printer_type_mask': 'net',
                      'requested_attributes':
-                        'name printer-object-attributes-tag',
+                        'name printer-attributes-tag',
                      'requested_user_name': 'john'}}})
     assert 'NAME "CUPS Get Classes"' in request, request
     assert 'OPERATION "CUPS-Get-Classes"' in request, request
@@ -168,7 +168,7 @@ def test_cups_get_classes_form():
     assert 'ATTR enum printer-type network' in request
     assert 'ATTR enum printer-type-mask net' in request
     assert ('ATTR keyword requested-attributes'
-            ' name printer-object-attributes-tag') in request
+            ' name printer-attributes-tag') in request
     assert 'ATTR name requested-user-name john' in request
 
 
@@ -231,7 +231,7 @@ def test_cups_get_printers_form():
                      'printer_type': 'network',
                      'printer_type_mask': 'net',
                      'requested_attributes':
-                        'name printer-object-attributes-tag',
+                        'name printer-attributes-tag',
                      'requested_user_name': 'john'}}})
     assert 'NAME "CUPS Get Printers"' in request, request
     assert 'OPERATION "CUPS-Get-Printers"' in request, request
@@ -241,7 +241,7 @@ def test_cups_get_printers_form():
     assert 'ATTR enum printer-type network' in request
     assert 'ATTR enum printer-type-mask net' in request
     assert ('ATTR keyword requested-attributes'
-            ' name printer-object-attributes-tag') in request
+            ' name printer-attributes-tag') in request
     assert 'ATTR name requested-user-name john' in request
 
 


### PR DESCRIPTION
As per [CUPS ipptoolfile documentation](http://www.cups.org/documentation.php/doc-1.7/man-ipptoolfile.html):
### Tags

Value and group tags correspond to the names from RFC 2911 and other IPP extension specifications. Here are  the group tags:

```
    event-notification-attributes-tag
    job-attributes-tag
    operation-attributes-tag
    printer-attributes-tag
    subscription-attributes-tag
    unsupported-attributes-tag
```
