### PR TITLE
Improvements to Get-Jobs Operation

### DIFF
--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -317,12 +317,14 @@ def get_job_attributes(uri,
 
 def get_jobs(uri,
              printer_uri=None,
+             requesting_user_name=colander.null,
              limit=colander.null,
              requested_attributes=colander.null,
              which_jobs=colander.null,
              my_jobs=colander.null):
     kw = {'header': {'operation_attributes':
                      {'printer_uri': printer_uri,
+                      'requesting_user_name': requesting_user_name,
                       'limit': limit,
                       'requested_attributes': requested_attributes,
                       'which_jobs': which_jobs,

--- a/pyipptool/tests/test_form.py
+++ b/pyipptool/tests/test_form.py
@@ -282,7 +282,8 @@ def test_get_jobs_form():
     request = get_jobs_form.render(
         {'header':
          {'operation_attributes':
-          {'requesting_user_name': 'yoda',
+          {'printer_uri': 'https://localhost:631/printers/p0',
+           'requesting_user_name': 'yoda',
            'limit': 1,
            'requested_attributes':
            'job-uri',
@@ -290,6 +291,7 @@ def test_get_jobs_form():
            'my_jobs': True}}})
     assert 'NAME "Get Jobs"' in request
     assert 'OPERATION "Get-Jobs"' in request
+    assert 'ATTR uri printer-uri https://localhost:631/printers/p0' in request
     assert 'ATTR name requesting-user-name yoda' in request
     assert 'ATTR integer limit 1' in request
     assert 'ATTR keyword requested-attributes job-uri' in request

--- a/pyipptool/tests/test_form.py
+++ b/pyipptool/tests/test_form.py
@@ -279,14 +279,18 @@ def test_get_job_attributes_form():
 
 def test_get_jobs_form():
     from pyipptool.forms import get_jobs_form
-    request = get_jobs_form.render({'header': {'operation_attributes':
-                                               {'limit': 1,
-                                                'requested_attributes':
-                                                'job-uri',
-                                                'which_jobs': 'pending',
-                                                'my_jobs': True}}})
+    request = get_jobs_form.render(
+        {'header':
+         {'operation_attributes':
+          {'requesting_user_name': 'yoda',
+           'limit': 1,
+           'requested_attributes':
+           'job-uri',
+           'which_jobs': 'pending',
+           'my_jobs': True}}})
     assert 'NAME "Get Jobs"' in request
     assert 'OPERATION "Get-Jobs"' in request
+    assert 'ATTR name requesting-user-name yoda' in request
     assert 'ATTR integer limit 1' in request
     assert 'ATTR keyword requested-attributes job-uri' in request
     assert 'ATTR keyword which-jobs pending' in request


### PR DESCRIPTION
As per [RFC 2911, section 3.2.6](http://tools.ietf.org/search/rfc2911#section-3.2.6):

> The "requesting-user-name" (name(MAX)) attribute SHOULD be
> supplied by the client as described in section 8.3.
