### PR TITLE
Changed default argument value for printer_uri to colander.null

### DIFF
--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -333,7 +333,7 @@ def cups_reject_jobs(uri,
 
 
 def get_job_attributes(uri,
-                       printer_uri=None,
+                       printer_uri=colander.null,
                        job_id=colander.null,
                        job_uri=colander.null,
                        requesting_user_name=colander.null,

--- a/pyipptool/tests/test_highlevel.py
+++ b/pyipptool/tests/test_highlevel.py
@@ -36,3 +36,29 @@ def test_cups_add_modify_printer(_call_ipptool):
     request = _call_ipptool._mock_mock_calls[0][1][1]
     assert 'printer-uri https://localhost:631/classes/PUBLIC-PDF' in request
     assert 'device-uri cups-pdf:/' in request
+
+
+@mock.patch.object(pyipptool, '_call_ipptool')
+def test_get_job_attributes_with_job_id(_call_ipptool):
+    from pyipptool import get_job_attributes
+    get_job_attributes(
+        'https://localhost:631/',
+        printer_uri='https://localhost:631/classes/PUBLIC-PDF',
+        job_id=2)
+    assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
+    request = _call_ipptool._mock_mock_calls[0][1][1]
+    assert 'printer-uri https://localhost:631/classes/PUBLIC-PDF' in request
+    assert 'job-id 2' in request
+    assert 'job-uri' not in request
+
+
+@mock.patch.object(pyipptool, '_call_ipptool')
+def test_get_job_attributes_with_job_uri(_call_ipptool):
+    from pyipptool import get_job_attributes
+    get_job_attributes(
+        'https://localhost:631/',
+        job_uri='https://localhost:631/jobs/2')
+    assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
+    request = _call_ipptool._mock_mock_calls[0][1][1]
+    assert 'job-uri https://localhost:631/jobs/2' in request
+    assert 'printer-uri' not in request


### PR DESCRIPTION
As stated in [RFC 2911, section 3.3.4](http://tools.ietf.org/search/rfc2911#section-3.3.4): 

> 3.3.4.1 Get-Job-Attributes Request
> 
>   The following groups of attributes are part of the Get-Job-Attributes
>   Request when the request is directed at a Job object:
> 
>   Group 1: Operation Attributes
> 
> ```
>  Target:
>    Either (1) the "printer-uri" (uri) plus "job-id"
>    (integer(1:MAX)) or (2) the "job-uri" (uri) operation
>    attribute(s) which define the target for this operation as
>    described in section 3.1.5.
> ```

one may pass either the `job-uri` **OR** (`printer-uri` **AND** `job-id`), in order to fetch the job attributes ... so we're allowing a `colander.null` value for the `printer_uri`, which makes it optional, and when not received, will not be included in the request.
