### PR TITLE
Always return raw response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,4 +66,19 @@ Create an infinite time subscription for printer-XYZ class for the ``rss`` notif
             notify_events='all',
             notify_lease_duration=0,
             notify_lease_expiration_time=0)
-    23
+    {'Name': 'Create Printer Subscription',
+     'Operation': 'Create-Printer-Subscription',
+     'RequestAttributes': [{'attributes-charset': 'utf-8',
+                            'attributes-natural-language': 'en',
+                            'printer-uri': 'http://localhost:631/classes/printer-XYZ',
+                            'requesting-user-name': 'admin'},
+                           {'notify-events': 'all',
+                            'notify-lease-duration': 0,
+                            'notify-lease-expiration-time': 0,
+                            'notify-recipient-uri': 'rss://'}],
+     'ResponseAttributes': [{'attributes-charset': 'utf-8',
+                             'attributes-natural-language': 'en'},
+                            {'notify-subscription-id': 23}],
+     'StatusCode': 'successful-ok',
+     'Successful': True,
+     'notify-subscription-id': 23}

--- a/pyipptool/core.py
+++ b/pyipptool/core.py
@@ -100,7 +100,7 @@ class IPPToolWrapper(object):
                           'job_uri': job_uri}}}
         request = release_job_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
+        return response['Tests'][0]
 
     def cancel_job(self, uri,
                    printer_uri=colander.null,
@@ -114,7 +114,7 @@ class IPPToolWrapper(object):
                           'purge_job': purge_job}}}
         request = cancel_job_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
+        return response['Tests'][0]
 
     def create_printer_subscription(
             self,
@@ -137,8 +137,7 @@ class IPPToolWrapper(object):
               'notify_lease_expiration_time': notify_lease_expiration_time}
         request = create_printer_subscription_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes'][1][
-            'notify-subscription-id']
+        return response['Tests'][0]
 
     def cups_add_modify_printer(self, uri,
                                 printer_uri=None,
@@ -176,8 +175,7 @@ class IPPToolWrapper(object):
 
         request = cups_add_modify_printer_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def cups_add_modify_class(self, uri,
                               printer_uri=None,
@@ -209,22 +207,19 @@ class IPPToolWrapper(object):
 
         request = cups_add_modify_class_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def cups_delete_printer(self, uri, printer_uri=None):
         kw = {'header': {'operation_attributes': {'printer_uri': printer_uri}}}
         request = cups_delete_printer_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def cups_delete_class(self, uri, printer_uri=None):
         kw = {'header': {'operation_attributes': {'printer_uri': printer_uri}}}
         request = cups_delete_class_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def cups_get_classes(self, uri,
                          first_printer_name=colander.null,
@@ -244,7 +239,7 @@ class IPPToolWrapper(object):
                          'requested_user_name': requested_user_name}}}
         request = cups_get_classes_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def cups_get_devices(self, uri,
                          device_class=colander.null,
@@ -262,7 +257,7 @@ class IPPToolWrapper(object):
                          'timeout': timeout}}}
         request = cups_get_devices_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def cups_get_ppds(self, uri,
                       exclude_schemes=colander.null,
@@ -291,7 +286,7 @@ class IPPToolWrapper(object):
                          }}}
         request = cups_get_ppds_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def cups_get_printers(self, uri,
                           first_printer_name=colander.null,
@@ -311,7 +306,7 @@ class IPPToolWrapper(object):
                          'requested_user_name': requested_user_name}}}
         request = cups_get_printers_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def cups_move_job(self, uri,
                       printer_uri=colander.null,
@@ -327,8 +322,7 @@ class IPPToolWrapper(object):
               'printer_state_message': printer_state_message}
         request = cups_move_job_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def cups_reject_jobs(self, uri,
                          printer_uri=None,
@@ -340,8 +334,7 @@ class IPPToolWrapper(object):
               'printer_state_message': printer_state_message}
         request = cups_reject_jobs_form.render(kw)
         response = self._call_ipptool(uri, request)
-        assert response['Tests'][0]['StatusCode'] == 'successful-ok', response
-        return True
+        return response['Tests'][0]
 
     def get_job_attributes(self, uri,
                            printer_uri=colander.null,
@@ -357,7 +350,7 @@ class IPPToolWrapper(object):
                          'requested_attributes': requested_attributes}}}
         request = get_job_attributes_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def get_jobs(self, uri,
                  printer_uri=None,
@@ -375,7 +368,7 @@ class IPPToolWrapper(object):
                          'my_jobs': my_jobs}}}
         request = get_jobs_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def get_printer_attributes(self, uri,
                                printer_uri=None,
@@ -387,7 +380,7 @@ class IPPToolWrapper(object):
                          'requested_attributes': requested_attributes}}}
         request = get_printer_attributes_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def get_subscriptions(self, uri,
                           printer_uri=None,
@@ -405,7 +398,7 @@ class IPPToolWrapper(object):
                          'my_subscriptions': my_subscriptions}}}
         request = get_subscriptions_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def cancel_subscription(self, uri,
                             printer_uri=None,
@@ -418,7 +411,7 @@ class IPPToolWrapper(object):
                 'notify_subscription_id': notify_subscription_id}}}
         request = cancel_subscription_form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def _pause_or_resume_printer(self, form, uri, printer_uri=None,
                                  requesting_user_name=colander.null):
@@ -427,7 +420,7 @@ class IPPToolWrapper(object):
                          'requesting_user_name': requesting_user_name}}}
         request = form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def pause_printer(self, *args, **kw):
         return self._pause_or_resume_printer(pause_printer_form, *args, **kw)
@@ -447,7 +440,7 @@ class IPPToolWrapper(object):
                  }}}
         request = form.render(kw)
         response = self._call_ipptool(uri, request)
-        return response['Tests'][0]['ResponseAttributes']
+        return response['Tests'][0]
 
     def hold_new_jobs(self, *args, **kw):
         return self._hold_or_release_new_jobs(hold_new_jobs_form, *args, **kw)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -33,7 +33,7 @@ def test_ipptool_create_printer_subscription(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_add_modify_printer(_call_ipptool):
     from pyipptool import cups_add_modify_printer
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_add_modify_printer(
         'https://localhost:631/',
         printer_uri='https://localhost:631/classes/PUBLIC-PDF',
@@ -121,7 +121,7 @@ def test_authentication():
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_release_job(_call_ipptool):
     from pyipptool import release_job
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     release_job('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -129,7 +129,7 @@ def test_release_job(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cancel_job(_call_ipptool):
     from pyipptool import cancel_job
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cancel_job('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -137,7 +137,7 @@ def test_cancel_job(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_add_modify_class(_call_ipptool):
     from pyipptool import cups_add_modify_class
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_add_modify_class('https://localhost:631/',
                           printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
@@ -146,7 +146,7 @@ def test_cups_add_modify_class(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_delete_printer(_call_ipptool):
     from pyipptool import cups_delete_printer
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_delete_printer('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -154,7 +154,7 @@ def test_cups_delete_printer(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_delete_class(_call_ipptool):
     from pyipptool import cups_delete_class
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_delete_class('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -162,7 +162,7 @@ def test_cups_delete_class(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_get_classes(_call_ipptool):
     from pyipptool import cups_get_classes
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_get_classes('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -170,7 +170,7 @@ def test_cups_get_classes(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_get_printers(_call_ipptool):
     from pyipptool import cups_get_printers
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_get_printers('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -178,7 +178,7 @@ def test_cups_get_printers(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_get_devices(_call_ipptool):
     from pyipptool import cups_get_devices
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_get_devices('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -186,7 +186,7 @@ def test_cups_get_devices(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_get_ppds(_call_ipptool):
     from pyipptool import cups_get_ppds
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_get_ppds('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -194,7 +194,7 @@ def test_cups_get_ppds(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_move_job(_call_ipptool):
     from pyipptool import cups_move_job
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_move_job('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -202,7 +202,7 @@ def test_cups_move_job(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cups_reject_jobs(_call_ipptool):
     from pyipptool import cups_reject_jobs
-    _call_ipptool.return_value = {'Tests': [{'StatusCode': 'successful-ok'}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cups_reject_jobs('https://localhost:631/')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -210,7 +210,7 @@ def test_cups_reject_jobs(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_get_jobs(_call_ipptool):
     from pyipptool import get_jobs
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     get_jobs('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -218,7 +218,7 @@ def test_get_jobs(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_get_printer_attributes(_call_ipptool):
     from pyipptool import get_printer_attributes
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     get_printer_attributes('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -226,7 +226,7 @@ def test_get_printer_attributes(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_get_subscriptions(_call_ipptool):
     from pyipptool import get_subscriptions
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     get_subscriptions('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -234,7 +234,7 @@ def test_get_subscriptions(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_pause_printer(_call_ipptool):
     from pyipptool import pause_printer
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     pause_printer('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -242,7 +242,7 @@ def test_pause_printer(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_hold_new_jobs(_call_ipptool):
     from pyipptool import hold_new_jobs
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     hold_new_jobs('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -250,7 +250,7 @@ def test_hold_new_jobs(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_release_held_new_jobs(_call_ipptool):
     from pyipptool import release_held_new_jobs
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     release_held_new_jobs('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -258,7 +258,7 @@ def test_release_held_new_jobs(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_resume_printer(_call_ipptool):
     from pyipptool import resume_printer
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     resume_printer('https://localhost:631/', printer_uri='')
     assert _call_ipptool._mock_mock_calls[0][1][0] == 'https://localhost:631/'
 
@@ -266,7 +266,7 @@ def test_resume_printer(_call_ipptool):
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
 def test_cancel_subscription(_call_ipptool):
     from pyipptool import cancel_subscription
-    _call_ipptool.return_value = {'Tests': [{'ResponseAttributes': ''}]}
+    _call_ipptool.return_value = {'Tests': [{}]}
     cancel_subscription('https://localhost:631/',
                         printer_uri='',
                         notify_subscription_id=3)


### PR DESCRIPTION
Returns raw response instead of trying to tell to the user if the request succeed or not.
Indeed cups is not consistent. It might return OK even in case of failure.
