### PR TITLE
Made corrections to the name of the IPP operation (related to #65)

### DIFF
--- a/pyipptool/__init__.py
+++ b/pyipptool/__init__.py
@@ -5,7 +5,7 @@ from .core import IPPToolWrapper
 config = get_config()
 
 wrapper = IPPToolWrapper(config)
-create_job_subscriptions = wrapper.create_job_subscriptions
+create_job_subscription = wrapper.create_job_subscription
 create_printer_subscription = wrapper. create_printer_subscription
 cancel_job = wrapper.cancel_job
 release_job = wrapper.release_job

--- a/pyipptool/core.py
+++ b/pyipptool/core.py
@@ -10,7 +10,7 @@ import colander
 
 from .forms import (cancel_job_form,
                     release_job_form,
-                    create_job_subscriptions_form,
+                    create_job_subscription_form,
                     create_printer_subscription_form,
                     cups_add_modify_class_form,
                     cups_add_modify_printer_form,
@@ -117,20 +117,20 @@ class IPPToolWrapper(object):
         response = self._call_ipptool(uri, request)
         return response['Tests'][0]
 
-    def create_job_subscriptions(self,
-                                 uri,
-                                 printer_uri=None,
-                                 requesting_user_name=None,
-                                 notify_job_id=None,
-                                 notify_recipient_uri=colander.null,
-                                 notify_pull_method=colander.null,
-                                 notify_events=colander.null,
-                                 notify_attributes=colander.null,
-                                 notify_charset=colander.null,
-                                 notify_natural_language=colander.null,
-                                 notify_time_interval=colander.null):
+    def create_job_subscription(self,
+                                uri,
+                                printer_uri=None,
+                                requesting_user_name=None,
+                                notify_job_id=None,
+                                notify_recipient_uri=colander.null,
+                                notify_pull_method=colander.null,
+                                notify_events=colander.null,
+                                notify_attributes=colander.null,
+                                notify_charset=colander.null,
+                                notify_natural_language=colander.null,
+                                notify_time_interval=colander.null):
         """
-        Create one or more Per-Job Subscription objects.
+        Create a per-job subscription object.
         """
         kw = {'header': {'operation_attributes':
                          {'printer_uri': printer_uri,
@@ -143,7 +143,7 @@ class IPPToolWrapper(object):
               'notify_charset': notify_charset,
               'notify_natural_language': notify_natural_language,
               'notify_time_interval': notify_time_interval}
-        request = create_job_subscriptions_form.render(kw)
+        request = create_job_subscription_form.render(kw)
         response = self._call_ipptool(uri, request)
         return response['Tests'][0]
 

--- a/pyipptool/forms.py
+++ b/pyipptool/forms.py
@@ -4,7 +4,7 @@ import deform.template
 
 from .schemas import (cancel_job_schema,
                       release_job_schema,
-                      create_job_subscriptions_schema,
+                      create_job_subscription_schema,
                       create_printer_subscription_schema,
                       cups_add_modify_class_schema,
                       cups_add_modify_printer_schema,
@@ -35,8 +35,8 @@ deform.Form.set_default_renderer(renderer)
 
 cancel_job_form = deform.Form(cancel_job_schema)
 release_job_form = deform.Form(release_job_schema)
-create_job_subscriptions_form = deform.Form(
-    create_job_subscriptions_schema)
+create_job_subscription_form = deform.Form(
+    create_job_subscription_schema)
 create_printer_subscription_form = deform.Form(
     create_printer_subscription_schema)
 cups_add_modify_printer_form = deform.Form(cups_add_modify_printer_schema)

--- a/pyipptool/schemas.py
+++ b/pyipptool/schemas.py
@@ -96,7 +96,7 @@ class SubscriptionOperationAttributes(OperationAttributesWithPrinterUri):
                                                widget=IPPAttributeWidget())
 
 
-class CreateJobSubscriptionsOperationAttributes(
+class CreateJobSubscriptionOperationAttributes(
         SubscriptionOperationAttributes):
     notify_job_id = colander.SchemaNode(colander.Integer(),
                                         widget=IPPAttributeWidget())
@@ -353,12 +353,12 @@ class CupsRejectJobsSchema(BaseIPPSchema):
         widget=IPPAttributeWidget())
 
 
-class CreateJobSubscriptionsSchema(BaseIPPSchema):
-    name = 'Create Job Subscriptions'
-    operation = 'Create-Job-Subscriptions'
+class CreateJobSubscriptionSchema(BaseIPPSchema):
+    name = 'Create Job Subscription'
+    operation = 'Create-Job-Subscription'
     object_attributes_tag = 'subscription-attributes-tag'
     header = HeaderIPPSchema(widget=IPPConstantTupleWidget())
-    header['operation_attributes'] = CreateJobSubscriptionsOperationAttributes(
+    header['operation_attributes'] = CreateJobSubscriptionOperationAttributes(
         widget=IPPTupleWidget())
     notify_recipient_uri = colander.SchemaNode(Uri(),
                                                widget=IPPAttributeWidget())
@@ -478,7 +478,7 @@ cancel_job_schema = CancelJobSchema(widget=IPPBodyWidget())
 
 release_job_schema = ReleaseJobSchema(widget=IPPBodyWidget())
 
-create_job_subscriptions_schema = CreateJobSubscriptionsSchema(
+create_job_subscription_schema = CreateJobSubscriptionSchema(
     widget=IPPBodyWidget())
 
 create_printer_subscription_schema = CreatePrinterSubscriptionSchema(

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -62,9 +62,9 @@ def test_create_printer_subscription_form():
     assert 'ATTR integer notify-lease-expiration-time 0' in request
 
 
-def test_create_job_subscriptions_form_for_pull_delivery_method():
-    from pyipptool.forms import create_job_subscriptions_form
-    request = create_job_subscriptions_form.render(
+def test_create_job_subscription_form_for_pull_delivery_method():
+    from pyipptool.forms import create_job_subscription_form
+    request = create_job_subscription_form.render(
         {'header': {'operation_attributes':
                     {'printer_uri': 'https://localhost:631/printer/p',
                      'requesting_user_name': 'admin',
@@ -75,8 +75,8 @@ def test_create_job_subscriptions_form_for_pull_delivery_method():
          'notify_charset': 'utf-8',
          'notify_natural_language': 'de',
          'notify_time_interval': 1})
-    assert 'NAME "Create Job Subscriptions"' in request
-    assert 'OPERATION "Create-Job-Subscriptions"' in request
+    assert 'NAME "Create Job Subscription"' in request
+    assert 'OPERATION "Create-Job-Subscription"' in request
     assert 'ATTR charset attributes-charset utf-8' in request
     assert 'ATTR language attributes-natural-language en' in request
     assert 'ATTR name requesting-user-name admin' in request

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -11,9 +11,9 @@ import pyipptool
 
 
 @mock.patch.object(pyipptool.wrapper, '_call_ipptool')
-def test_ipptool_create_job_subscriptions_pull_delivery_method(_call_ipptool):
-    from pyipptool import create_job_subscriptions
-    create_job_subscriptions(
+def test_ipptool_create_job_subscription_pull_delivery_method(_call_ipptool):
+    from pyipptool import create_job_subscription
+    create_job_subscription(
         'https://localhost:631/',
         printer_uri='https://localhost:631/printer/p',
         requesting_user_name='ecp_admin',


### PR DESCRIPTION
RFC 3995 refers to the job (and printer) subscription operations in the plural form:

> [Create-Job-Subscriptions Operation](https://tools.ietf.org/html/rfc3995#section-11.1.1)

but it does not work. It must be used in the singular form: `Create-Job-Subscription`
