### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ pyipptool
 .. image:: https://coveralls.io/repos/ezeep/pyipptool/badge.png
   :target: https://coveralls.io/r/ezeep/pyipptool
 
-.. image:: https://pypip.in/v/pyipptool/badge.png
+.. image:: https://img.shields.io/pypi/v/pyipptool.svg
    :target: https://crate.io/packages/pyipptool/
    :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyipptool))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyipptool`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.